### PR TITLE
Move back to object-id and fix transcript page links

### DIFF
--- a/_includes/collection-banner.html
+++ b/_includes/collection-banner.html
@@ -41,7 +41,7 @@
                                 </a>
                                 <div class="dropdown-menu dropdown-menu-end" style="z-index: 10;">
                                     {% for transcript in site.transcripts %}
-                                    <a class="dropdown-item" href="{{ transcript.objectid | prepend: '/transcripts/' | relative_url }}.html">{{transcript.title}}</a>
+                                    <a class="dropdown-item" href="{{ transcript.object-id | prepend: '/transcripts/' | relative_url }}.html">{{transcript.title}}</a>
                                     {%endfor%}
                                 </div>
                             </li>

--- a/_includes/collection-nav.html
+++ b/_includes/collection-nav.html
@@ -37,7 +37,7 @@
                     </a>
                     <div class="dropdown-menu dropdown-menu-end">
                         {% for transcript in site.transcripts %}
-                        <a class="dropdown-item" href="{{ transcript.objectid | prepend: '/transcripts/' | relative_url }}.html">{{transcript.title}}</a>
+                        <a class="dropdown-item" href="{{ transcript.object-id | prepend: '/transcripts/' | relative_url }}.html">{{transcript.title}}</a>
                         {%endfor%}
                     </div>
                 </li>

--- a/_layouts/transcript.html
+++ b/_layouts/transcript.html
@@ -1,11 +1,11 @@
 ---
 layout: default
 ---
-{% if page.objectid == 'all' %}
+{% if page.object-id == 'all' %}
 {% assign transcripts = site.data.transcripts %}
 
 {% else %}
-{% assign items = site.data.transcripts[page.objectid] %}
+{% assign items = site.data.transcripts[page.object-id] %}
 {%- comment -%} find all words used in the subject metadata {%- endcomment -%}
 {%- assign min-count = 1 -%}
 {%- assign raw-subjects = items | map: "tags" | compact | join: ";" | split: ";" -%}
@@ -48,7 +48,7 @@ endcapture -%}
         player/soundcloud.html %}{%
         endif %}
       </div>
-      {% unless page.objectid == 'all' %}
+      {% unless page.object-id == 'all' %}
       <div class="vizdiv">
         <h3 class="mt-5 mb-0">Topics:</h3>
         <svg class="chart" width="100%" height="100px" style="overflow: visible">
@@ -56,7 +56,7 @@ endcapture -%}
           {% assign my_integer = forloop.length %}
           {% assign my_float = my_integer | times: 1.0 %}
           {% assign rect-width = 100 | divided_by: my_float %}
-          <a href="{{ forloop.index | prepend: transcript-name | prepend: '.html#' | prepend: transcript-name | prepend: '/transcripts/' | relative_url }}">
+          <a href="{{ forloop.index | prepend: page.object-id | prepend: '#' }}">
             <rect x="{{forloop.index0 | times: rect-width }}%" y="20" width="{{rect-width}}%" height="50" data-toggle="tooltip" data-placement="top" class="{{item.tags | replace: ';', ' '}}" title="{{ item.words }}{% if item.tags %}(Subjects: {{ item.tags | replace: ';', ', ' }}){%endif%}"></rect>
           </a>
           {%endfor%}</svg>
@@ -69,7 +69,7 @@ endcapture -%}
             <option value="#" class="reset" selected="selected reset">Filter by Topic</option>
             <option value="all" selected="selected">On All Topics</option>
             {% assign filters = site.data.filters %}
-            {% if page.objectid == 'all' %}
+            {% if page.object-id == 'all' %}
             {% for filter in filters %}
             <option value="{{ filter.tag }}">{{filter.description | capitalize}} ({{filter.tag}})</option>
             {% endfor %}
@@ -114,10 +114,10 @@ endcapture -%}
 
 
       <div id="contents-container" class="pe-5">
-        {% if page.objectid == 'all' %}
+        {% if page.object-id == 'all' %}
         {% for transcript in site.data.transcripts %}{%assign transcript-name = transcript[0] %}
         {% for item in transcript[1] %}
-        <div id="{{page.objectid}}{{ forloop.index }}" class="row line {{item.tags | replace: ';', ' '}} my-3">
+        <div id="{{page.object-id}}{{ forloop.index }}" class="row line {{item.tags | replace: ';', ' '}} my-3">
           <div class="linenum col-1 small mt-2"><a href="{{ forloop.index | prepend: transcript-name | prepend: '.html#' | prepend: transcript-name | prepend: '/transcripts/' | relative_url }}">{{transcript-name}}-{{ forloop.index }}</a></div>
           <p class="words col-10 col-md-8 col-print-10 my-3">
             {%if item.speaker%}{{item.speaker | remove: ":"}}: {%endif%}{{item.words}}
@@ -130,7 +130,7 @@ endcapture -%}
         {% assign prev_index = forloop.index0 | times: 1 | minus: 1 %}
         {% assign prev_speaker = items[prev_index].speaker %}
         {% assign mod = forloop.index | plus: 1 | modulo: 5 %}
-        <div id="{{page.objectid}}{{ forloop.index }}" class="row line {{item.tags | replace: ';', ' '}} my-1">
+        <div id="{{page.object-id}}{{ forloop.index }}" class="row line {{item.tags | replace: ';', ' '}} my-1">
 
           <p class="words col-md-10 col-lg-8 col-print-12 pr-0">
 

--- a/_layouts/visualization.html
+++ b/_layouts/visualization.html
@@ -23,7 +23,7 @@ layout: default
   <br />
   {% for transcript in transcripts %}{%assign transcript-name = transcript[0] %}
   <div class="vizdiv">
-    <h3 x="0" y="0" data-id="{{transcript-name}}" style="cursor:pointer;" class="mt-4 toggle_int {{transcript-name}}">{% for t in site.transcripts %}{% if t.objectid == transcript-name %}{{t.title}}{% endif %}{% endfor%}<i class="fas fa-filter"></i> <small>Click to filter</small></h3>
+    <h3 x="0" y="0" data-id="{{transcript-name}}" style="cursor:pointer;" class="mt-4 toggle_int {{transcript-name}}">{% for t in site.transcripts %}{% if t.object-id == transcript-name %}{{t.title}}{% endif %}{% endfor%}<i class="fas fa-filter"></i> <small>Click to filter</small></h3>
     <svg class="chart {{transcript-name}}" width="100%" height="100px" style="overflow: visible">
       {% for item in transcript[1] %}
       {% assign my_integer = forloop.length %}
@@ -38,13 +38,13 @@ layout: default
 </div>
 <br />
 <hr /><br />
-<div class="container d-md-none">
+<div class="container d-none">
   <h2>Contents</h2>
 
 
   {% for transcript in site.data.transcripts %}{%assign transcript-name = transcript[0] %}
-  {%capture audiovideo-id %}{%for item in site.transcripts%}{%if item.objectid == transcript-name %}{{item.audiovideo-id}}{%endif%}{%endfor%}{% endcapture %}
-  {%capture avlink %}{%for item in site.transcripts%}{%if item.objectid == transcript-name %}timestamp/{{item.av_source}}.html{%endif%}{%endfor%}{% endcapture %}
+  {%capture audiovideo-id %}{%for item in site.transcripts%}{%if item.object-id == transcript-name %}{{item.audiovideo-id}}{%endif%}{%endfor%}{% endcapture %}
+  {%capture avlink %}{%for item in site.transcripts%}{%if item.object-id == transcript-name %}timestamp/{{item.av_source}}.html{%endif%}{%endfor%}{% endcapture %}
   {% for item in transcript[1] %}
   {% if forloop.first %}
   <div class="contentsdiv">

--- a/_transcripts/all.md
+++ b/_transcripts/all.md
@@ -1,5 +1,5 @@
 ---
-objectid: all
+object-id: all
 transcript: transcript-all  
 first-name: all
 last-name: subjects   

--- a/_transcripts/bsha.md
+++ b/_transcripts/bsha.md
@@ -1,5 +1,5 @@
 ---
-objectid: bsha
+object-id: bsha
 title: Bernadette Suda Horiuchi Interview Audio
 date-interviewed: 2009-05-19
 location: Bellevue, WA

--- a/_transcripts/emn1a.md
+++ b/_transcripts/emn1a.md
@@ -1,5 +1,5 @@
 ---
-objectid: emn1a
+object-id: emn1a
 title: Elva Moore Nicholas Interview   
 date-interviewed: 1976-03-22
 location: Franklin County, Washington

--- a/_transcripts/emn2a.md
+++ b/_transcripts/emn2a.md
@@ -1,5 +1,5 @@
 ---
-objectid: emn2a
+object-id: emn2a
 title: Elva Moore Nicholas Interview   
 date-interviewed: 1976-03-22
 location: Franklin County, Washington

--- a/_transcripts/frca.md
+++ b/_transcripts/frca.md
@@ -1,5 +1,5 @@
 ---
-objectid: frca
+object-id: frca
 title: Father Ricard Cebula Interview 
 date-interviewed: 1975-12-19
 location: Tacoma, WA

--- a/_transcripts/gda.md
+++ b/_transcripts/gda.md
@@ -1,5 +1,5 @@
 ---
-objectid: gda
+object-id: gda
 title: Gus Demus Interview  
 date-interviewed: 1975-10-24
 location: Ephrata, Washington

--- a/_transcripts/ihga.md
+++ b/_transcripts/ihga.md
@@ -1,5 +1,5 @@
 ---
-objectid: ihga
+object-id: ihga
 title: Mrs. Irene Grayson Interview 
 date-interviewed: 1975-04-17
 location: Roslyn, Washington

--- a/_transcripts/mlmlla.md
+++ b/_transcripts/mlmlla.md
@@ -1,5 +1,5 @@
 ---
-objectid: mlmlla
+object-id: mlmlla
 title: Mi Lew and Marie Lee Lew Interview 
 date-interviewed: 1975-11-20
 location: Walla Walla, Washington

--- a/_transcripts/msa.md
+++ b/_transcripts/msa.md
@@ -1,5 +1,5 @@
 ---
-objectid: msa
+object-id: msa
 title: Martin Sampson Interview  
 date-interviewed: 1975-11-06
 location: Skagit City, WA

--- a/_transcripts/msca.md
+++ b/_transcripts/msca.md
@@ -1,5 +1,5 @@
 ---
-objectid: msca
+object-id: msca
 title: Mary Stella Calabrese Interview 
 date-interviewed: 1975-11-13
 location: Tacoma, WA

--- a/_transcripts/tma.md
+++ b/_transcripts/tma.md
@@ -1,5 +1,5 @@
 ---
-objectid: tma
+object-id: tma
 title: Toribio Madayag Interview 
 date-interviewed: 1975-07-02
 location: Grays Harbor, Washington

--- a/pages/about.md
+++ b/pages/about.md
@@ -2,7 +2,7 @@
 layout: page
 title: About 
 order: 1
-objectid: about
+object-id: about
 permalink: /about.html
 ---
 # About {{site.title}}

--- a/pages/transcripts.html
+++ b/pages/transcripts.html
@@ -15,7 +15,7 @@ permalink: transcripts.html
       <h3 class="card-title">{{transcript.title}}</h3>
       {% if transcript.date-interviewed%}<h6 class="card-subtitle mb-2 text-muted">{{transcript.date-interviewed}}</h6>{%endif%}
     
-      <a href="transcripts/{{transcript.objectid}}.html" class="card-link stretched-link">Go to interview</a>
+      <a href="transcripts/{{transcript.object-id}}.html" class="card-link stretched-link">Go to interview</a>
    
     </div>
 </div>

--- a/pages/visualizations.md
+++ b/pages/visualizations.md
@@ -2,7 +2,7 @@
 layout: visualization
 title: Visualizations
 order: 2
-objectid: visualizations
+object-id: visualizations
 filtersheet: filters
 filter: tags
 permalink: /subjects.html

--- a/transcripts_list.html
+++ b/transcripts_list.html
@@ -14,7 +14,7 @@ layout: default
       <h3 class="card-title">{{transcript.title}}</h3>
       {% if transcript.date-interviewed%}<h6 class="card-subtitle mb-2 text-muted">{{transcript.date-interviewed}}</h6>{%endif%}
     
-      <a href="transcripts/{{transcript.objectid}}.html" class="card-link">Go to interview</a>
+      <a href="transcripts/{{transcript.object-id}}.html" class="card-link">Go to interview</a>
    
     </div>
 </div>


### PR DESCRIPTION
Hi Andrew, 

I went back to an object-id base as I want people to be able to upgrade older OHD repositories if they'd like. 

I also fixed a linking problem on the transcript page itself -- the topic visualization rectangles were reloading the page rather than scrolling to an anchor. 

Wanted to make sure your repo was up to date with the base version. 